### PR TITLE
ARCH-1615 - Actions maintenance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,10 @@ on:
   # trigger because checkout, build, format and checking for changes do not need elevated
   # permissions to the repository.  The reduced permissions for public forks is adequate.
   pull_request:
-    paths-ignore:
-      - '**.md'
+    # Don't include any specific paths here so we always get a build that produces a status
+    # check that our Branch Protection Rules can use.  Having a status check also allows us
+    # to require that branches be up to date before they are merged.
+
 jobs:
   build:
     runs-on: ${{ matrix.operating-system }}
@@ -17,11 +19,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup Node.js 14
-        uses: actions/setup-node@v1
+        uses: actions/checkout@v3
+      - name: Setup Node.js 16
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: Build
         run: npm run build
       - name: Format

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -43,7 +43,7 @@ jobs:
       # See https://github.com/im-open/git-version-lite for more details around how to increment
       # major/minor/patch through commit messages
       - name: Increment the version
-        uses: im-open/git-version-lite@v2.1.0
+        uses: im-open/git-version-lite@v2.1.1
         with:
           create-ref: true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -15,6 +15,12 @@ on:
   #      reviewed, approved by a CODEOWNER and merged
   pull_request_target:
     types: [closed]
+    paths:
+      - 'dist/**'
+      - 'src/**'
+      - 'action.yml'
+      - 'package.json'
+      - 'package-lock.json'
 
 jobs:
   increment-version:
@@ -28,7 +34,7 @@ jobs:
       # on a pull_request_target.  But we need to be extra careful not to trigger any script
       # that may operate on PR controlled contents like in the case of npm install.
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: main
           fetch-depth: 0
@@ -37,7 +43,7 @@ jobs:
       # See https://github.com/im-open/git-version-lite for more details around how to increment
       # major/minor/patch through commit messages
       - name: Increment the version
-        uses: im-open/git-version-lite@v2.0.6
+        uses: im-open/git-version-lite@v2.1.0
         with:
           create-ref: true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
           
       - name: Check for an npm cache
         id: has-npm-cache
-        uses: im-open/check-for-cache@v1.0.0
+        uses: im-open/check-for-cache@v1.1.0
         with:
           paths:  '**/node_modules'
           key: ${{ env.NPM_CACHE_KEY }}
@@ -84,7 +84,7 @@ jobs:
         
       - name: Download the node_modules folder from the cache
         id: get-cached-node-modules
-        uses: im-open/restore-cache@v1.0.1
+        uses: im-open/restore-cache@v1.1.0
         with:
           key: ${{ needs.set-cache-keys.outputs.NPM_MODULES_CACHE_KEY }}
           path: '**/node_modules'

--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ outputs:
   primary-key:
     description: 'The primary key that should be used when saving the cache.'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: './dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,17 +4,45 @@
     /***/ 7351: /***/ function (__unused_webpack_module, exports, __nccwpck_require__) {
       'use strict';
 
+      var __createBinding =
+        (this && this.__createBinding) ||
+        (Object.create
+          ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              Object.defineProperty(o, k2, {
+                enumerable: true,
+                get: function () {
+                  return m[k];
+                }
+              });
+            }
+          : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+            });
+      var __setModuleDefault =
+        (this && this.__setModuleDefault) ||
+        (Object.create
+          ? function (o, v) {
+              Object.defineProperty(o, 'default', { enumerable: true, value: v });
+            }
+          : function (o, v) {
+              o['default'] = v;
+            });
       var __importStar =
         (this && this.__importStar) ||
         function (mod) {
           if (mod && mod.__esModule) return mod;
           var result = {};
           if (mod != null)
-            for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-          result['default'] = mod;
+            for (var k in mod)
+              if (k !== 'default' && Object.hasOwnProperty.call(mod, k))
+                __createBinding(result, mod, k);
+          __setModuleDefault(result, mod);
           return result;
         };
       Object.defineProperty(exports, '__esModule', { value: true });
+      exports.issue = exports.issueCommand = void 0;
       const os = __importStar(__nccwpck_require__(2087));
       const utils_1 = __nccwpck_require__(5278);
       /**
@@ -93,6 +121,43 @@
     /***/ 2186: /***/ function (__unused_webpack_module, exports, __nccwpck_require__) {
       'use strict';
 
+      var __createBinding =
+        (this && this.__createBinding) ||
+        (Object.create
+          ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              Object.defineProperty(o, k2, {
+                enumerable: true,
+                get: function () {
+                  return m[k];
+                }
+              });
+            }
+          : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+            });
+      var __setModuleDefault =
+        (this && this.__setModuleDefault) ||
+        (Object.create
+          ? function (o, v) {
+              Object.defineProperty(o, 'default', { enumerable: true, value: v });
+            }
+          : function (o, v) {
+              o['default'] = v;
+            });
+      var __importStar =
+        (this && this.__importStar) ||
+        function (mod) {
+          if (mod && mod.__esModule) return mod;
+          var result = {};
+          if (mod != null)
+            for (var k in mod)
+              if (k !== 'default' && Object.hasOwnProperty.call(mod, k))
+                __createBinding(result, mod, k);
+          __setModuleDefault(result, mod);
+          return result;
+        };
       var __awaiter =
         (this && this.__awaiter) ||
         function (thisArg, _arguments, P, generator) {
@@ -124,22 +189,36 @@
             step((generator = generator.apply(thisArg, _arguments || [])).next());
           });
         };
-      var __importStar =
-        (this && this.__importStar) ||
-        function (mod) {
-          if (mod && mod.__esModule) return mod;
-          var result = {};
-          if (mod != null)
-            for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-          result['default'] = mod;
-          return result;
-        };
       Object.defineProperty(exports, '__esModule', { value: true });
+      exports.getIDToken =
+        exports.getState =
+        exports.saveState =
+        exports.group =
+        exports.endGroup =
+        exports.startGroup =
+        exports.info =
+        exports.notice =
+        exports.warning =
+        exports.error =
+        exports.debug =
+        exports.isDebug =
+        exports.setFailed =
+        exports.setCommandEcho =
+        exports.setOutput =
+        exports.getBooleanInput =
+        exports.getMultilineInput =
+        exports.getInput =
+        exports.addPath =
+        exports.setSecret =
+        exports.exportVariable =
+        exports.ExitCode =
+          void 0;
       const command_1 = __nccwpck_require__(7351);
       const file_command_1 = __nccwpck_require__(717);
       const utils_1 = __nccwpck_require__(5278);
       const os = __importStar(__nccwpck_require__(2087));
       const path = __importStar(__nccwpck_require__(5622));
+      const oidc_utils_1 = __nccwpck_require__(8041);
       /**
        * The code to exit an action
        */
@@ -168,12 +247,12 @@
         process.env[name] = convertedVal;
         const filePath = process.env['GITHUB_ENV'] || '';
         if (filePath) {
-          const delimiter = '_GitHubActionsFileCommandDelimeter_';
-          const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
-          file_command_1.issueCommand('ENV', commandValue);
-        } else {
-          command_1.issueCommand('set-env', { name }, convertedVal);
+          return file_command_1.issueFileCommand(
+            'ENV',
+            file_command_1.prepareKeyValueMessage(name, val)
+          );
         }
+        command_1.issueCommand('set-env', { name }, convertedVal);
       }
       exports.exportVariable = exportVariable;
       /**
@@ -191,7 +270,7 @@
       function addPath(inputPath) {
         const filePath = process.env['GITHUB_PATH'] || '';
         if (filePath) {
-          file_command_1.issueCommand('PATH', inputPath);
+          file_command_1.issueFileCommand('PATH', inputPath);
         } else {
           command_1.issueCommand('add-path', {}, inputPath);
         }
@@ -199,7 +278,9 @@
       }
       exports.addPath = addPath;
       /**
-       * Gets the value of an input.  The value is also trimmed.
+       * Gets the value of an input.
+       * Unless trimWhitespace is set to false in InputOptions, the value is also trimmed.
+       * Returns an empty string if the value is not defined.
        *
        * @param     name     name of the input to get
        * @param     options  optional. See InputOptions.
@@ -210,9 +291,52 @@
         if (options && options.required && !val) {
           throw new Error(`Input required and not supplied: ${name}`);
         }
+        if (options && options.trimWhitespace === false) {
+          return val;
+        }
         return val.trim();
       }
       exports.getInput = getInput;
+      /**
+       * Gets the values of an multiline input.  Each value is also trimmed.
+       *
+       * @param     name     name of the input to get
+       * @param     options  optional. See InputOptions.
+       * @returns   string[]
+       *
+       */
+      function getMultilineInput(name, options) {
+        const inputs = getInput(name, options)
+          .split('\n')
+          .filter(x => x !== '');
+        if (options && options.trimWhitespace === false) {
+          return inputs;
+        }
+        return inputs.map(input => input.trim());
+      }
+      exports.getMultilineInput = getMultilineInput;
+      /**
+       * Gets the input value of the boolean type in the YAML 1.2 "core schema" specification.
+       * Support boolean input list: `true | True | TRUE | false | False | FALSE` .
+       * The return value is also in boolean type.
+       * ref: https://yaml.org/spec/1.2/spec.html#id2804923
+       *
+       * @param     name     name of the input to get
+       * @param     options  optional. See InputOptions.
+       * @returns   boolean
+       */
+      function getBooleanInput(name, options) {
+        const trueValue = ['true', 'True', 'TRUE'];
+        const falseValue = ['false', 'False', 'FALSE'];
+        const val = getInput(name, options);
+        if (trueValue.includes(val)) return true;
+        if (falseValue.includes(val)) return false;
+        throw new TypeError(
+          `Input does not meet YAML 1.2 "Core Schema" specification: ${name}\n` +
+            `Support boolean input list: \`true | True | TRUE | false | False | FALSE\``
+        );
+      }
+      exports.getBooleanInput = getBooleanInput;
       /**
        * Sets the value of an output.
        *
@@ -221,7 +345,15 @@
        */
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       function setOutput(name, value) {
-        command_1.issueCommand('set-output', { name }, value);
+        const filePath = process.env['GITHUB_OUTPUT'] || '';
+        if (filePath) {
+          return file_command_1.issueFileCommand(
+            'OUTPUT',
+            file_command_1.prepareKeyValueMessage(name, value)
+          );
+        }
+        process.stdout.write(os.EOL);
+        command_1.issueCommand('set-output', { name }, utils_1.toCommandValue(value));
       }
       exports.setOutput = setOutput;
       /**
@@ -267,19 +399,42 @@
       /**
        * Adds an error issue
        * @param message error issue message. Errors will be converted to string via toString()
+       * @param properties optional properties to add to the annotation.
        */
-      function error(message) {
-        command_1.issue('error', message instanceof Error ? message.toString() : message);
+      function error(message, properties = {}) {
+        command_1.issueCommand(
+          'error',
+          utils_1.toCommandProperties(properties),
+          message instanceof Error ? message.toString() : message
+        );
       }
       exports.error = error;
       /**
-       * Adds an warning issue
+       * Adds a warning issue
        * @param message warning issue message. Errors will be converted to string via toString()
+       * @param properties optional properties to add to the annotation.
        */
-      function warning(message) {
-        command_1.issue('warning', message instanceof Error ? message.toString() : message);
+      function warning(message, properties = {}) {
+        command_1.issueCommand(
+          'warning',
+          utils_1.toCommandProperties(properties),
+          message instanceof Error ? message.toString() : message
+        );
       }
       exports.warning = warning;
+      /**
+       * Adds a notice issue
+       * @param message notice issue message. Errors will be converted to string via toString()
+       * @param properties optional properties to add to the annotation.
+       */
+      function notice(message, properties = {}) {
+        command_1.issueCommand(
+          'notice',
+          utils_1.toCommandProperties(properties),
+          message instanceof Error ? message.toString() : message
+        );
+      }
+      exports.notice = notice;
       /**
        * Writes info to log with console.log.
        * @param message info message
@@ -338,7 +493,14 @@
        */
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       function saveState(name, value) {
-        command_1.issueCommand('save-state', { name }, value);
+        const filePath = process.env['GITHUB_STATE'] || '';
+        if (filePath) {
+          return file_command_1.issueFileCommand(
+            'STATE',
+            file_command_1.prepareKeyValueMessage(name, value)
+          );
+        }
+        command_1.issueCommand('save-state', { name }, utils_1.toCommandValue(value));
       }
       exports.saveState = saveState;
       /**
@@ -351,6 +513,54 @@
         return process.env[`STATE_${name}`] || '';
       }
       exports.getState = getState;
+      function getIDToken(aud) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return yield oidc_utils_1.OidcClient.getIDToken(aud);
+        });
+      }
+      exports.getIDToken = getIDToken;
+      /**
+       * Summary exports
+       */
+      var summary_1 = __nccwpck_require__(1327);
+      Object.defineProperty(exports, 'summary', {
+        enumerable: true,
+        get: function () {
+          return summary_1.summary;
+        }
+      });
+      /**
+       * @deprecated use core.summary
+       */
+      var summary_2 = __nccwpck_require__(1327);
+      Object.defineProperty(exports, 'markdownSummary', {
+        enumerable: true,
+        get: function () {
+          return summary_2.markdownSummary;
+        }
+      });
+      /**
+       * Path exports
+       */
+      var path_utils_1 = __nccwpck_require__(2981);
+      Object.defineProperty(exports, 'toPosixPath', {
+        enumerable: true,
+        get: function () {
+          return path_utils_1.toPosixPath;
+        }
+      });
+      Object.defineProperty(exports, 'toWin32Path', {
+        enumerable: true,
+        get: function () {
+          return path_utils_1.toWin32Path;
+        }
+      });
+      Object.defineProperty(exports, 'toPlatformPath', {
+        enumerable: true,
+        get: function () {
+          return path_utils_1.toPlatformPath;
+        }
+      });
       //# sourceMappingURL=core.js.map
 
       /***/
@@ -360,23 +570,52 @@
       'use strict';
 
       // For internal use, subject to change.
+      var __createBinding =
+        (this && this.__createBinding) ||
+        (Object.create
+          ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              Object.defineProperty(o, k2, {
+                enumerable: true,
+                get: function () {
+                  return m[k];
+                }
+              });
+            }
+          : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+            });
+      var __setModuleDefault =
+        (this && this.__setModuleDefault) ||
+        (Object.create
+          ? function (o, v) {
+              Object.defineProperty(o, 'default', { enumerable: true, value: v });
+            }
+          : function (o, v) {
+              o['default'] = v;
+            });
       var __importStar =
         (this && this.__importStar) ||
         function (mod) {
           if (mod && mod.__esModule) return mod;
           var result = {};
           if (mod != null)
-            for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-          result['default'] = mod;
+            for (var k in mod)
+              if (k !== 'default' && Object.hasOwnProperty.call(mod, k))
+                __createBinding(result, mod, k);
+          __setModuleDefault(result, mod);
           return result;
         };
       Object.defineProperty(exports, '__esModule', { value: true });
+      exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
       // We use any as a valid input type
       /* eslint-disable @typescript-eslint/no-explicit-any */
       const fs = __importStar(__nccwpck_require__(5747));
       const os = __importStar(__nccwpck_require__(2087));
+      const uuid_1 = __nccwpck_require__(8974);
       const utils_1 = __nccwpck_require__(5278);
-      function issueCommand(command, message) {
+      function issueFileCommand(command, message) {
         const filePath = process.env[`GITHUB_${command}`];
         if (!filePath) {
           throw new Error(`Unable to find environment variable for file command ${command}`);
@@ -388,8 +627,535 @@
           encoding: 'utf8'
         });
       }
-      exports.issueCommand = issueCommand;
+      exports.issueFileCommand = issueFileCommand;
+      function prepareKeyValueMessage(key, value) {
+        const delimiter = `ghadelimiter_${uuid_1.v4()}`;
+        const convertedValue = utils_1.toCommandValue(value);
+        // These should realistically never happen, but just in case someone finds a
+        // way to exploit uuid generation let's not allow keys or values that contain
+        // the delimiter.
+        if (key.includes(delimiter)) {
+          throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
+        }
+        if (convertedValue.includes(delimiter)) {
+          throw new Error(
+            `Unexpected input: value should not contain the delimiter "${delimiter}"`
+          );
+        }
+        return `${key}<<${delimiter}${os.EOL}${convertedValue}${os.EOL}${delimiter}`;
+      }
+      exports.prepareKeyValueMessage = prepareKeyValueMessage;
       //# sourceMappingURL=file-command.js.map
+
+      /***/
+    },
+
+    /***/ 8041: /***/ function (__unused_webpack_module, exports, __nccwpck_require__) {
+      'use strict';
+
+      var __awaiter =
+        (this && this.__awaiter) ||
+        function (thisArg, _arguments, P, generator) {
+          function adopt(value) {
+            return value instanceof P
+              ? value
+              : new P(function (resolve) {
+                  resolve(value);
+                });
+          }
+          return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+              try {
+                step(generator.next(value));
+              } catch (e) {
+                reject(e);
+              }
+            }
+            function rejected(value) {
+              try {
+                step(generator['throw'](value));
+              } catch (e) {
+                reject(e);
+              }
+            }
+            function step(result) {
+              result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+          });
+        };
+      Object.defineProperty(exports, '__esModule', { value: true });
+      exports.OidcClient = void 0;
+      const http_client_1 = __nccwpck_require__(1404);
+      const auth_1 = __nccwpck_require__(6758);
+      const core_1 = __nccwpck_require__(2186);
+      class OidcClient {
+        static createHttpClient(allowRetry = true, maxRetry = 10) {
+          const requestOptions = {
+            allowRetries: allowRetry,
+            maxRetries: maxRetry
+          };
+          return new http_client_1.HttpClient(
+            'actions/oidc-client',
+            [new auth_1.BearerCredentialHandler(OidcClient.getRequestToken())],
+            requestOptions
+          );
+        }
+        static getRequestToken() {
+          const token = process.env['ACTIONS_ID_TOKEN_REQUEST_TOKEN'];
+          if (!token) {
+            throw new Error('Unable to get ACTIONS_ID_TOKEN_REQUEST_TOKEN env variable');
+          }
+          return token;
+        }
+        static getIDTokenUrl() {
+          const runtimeUrl = process.env['ACTIONS_ID_TOKEN_REQUEST_URL'];
+          if (!runtimeUrl) {
+            throw new Error('Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable');
+          }
+          return runtimeUrl;
+        }
+        static getCall(id_token_url) {
+          var _a;
+          return __awaiter(this, void 0, void 0, function* () {
+            const httpclient = OidcClient.createHttpClient();
+            const res = yield httpclient.getJson(id_token_url).catch(error => {
+              throw new Error(`Failed to get ID Token. \n 
+        Error Code : ${error.statusCode}\n 
+        Error Message: ${error.result.message}`);
+            });
+            const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
+            if (!id_token) {
+              throw new Error('Response json body do not have ID Token field');
+            }
+            return id_token;
+          });
+        }
+        static getIDToken(audience) {
+          return __awaiter(this, void 0, void 0, function* () {
+            try {
+              // New ID Token is requested from action service
+              let id_token_url = OidcClient.getIDTokenUrl();
+              if (audience) {
+                const encodedAudience = encodeURIComponent(audience);
+                id_token_url = `${id_token_url}&audience=${encodedAudience}`;
+              }
+              core_1.debug(`ID token url is ${id_token_url}`);
+              const id_token = yield OidcClient.getCall(id_token_url);
+              core_1.setSecret(id_token);
+              return id_token;
+            } catch (error) {
+              throw new Error(`Error message: ${error.message}`);
+            }
+          });
+        }
+      }
+      exports.OidcClient = OidcClient;
+      //# sourceMappingURL=oidc-utils.js.map
+
+      /***/
+    },
+
+    /***/ 2981: /***/ function (__unused_webpack_module, exports, __nccwpck_require__) {
+      'use strict';
+
+      var __createBinding =
+        (this && this.__createBinding) ||
+        (Object.create
+          ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              Object.defineProperty(o, k2, {
+                enumerable: true,
+                get: function () {
+                  return m[k];
+                }
+              });
+            }
+          : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+            });
+      var __setModuleDefault =
+        (this && this.__setModuleDefault) ||
+        (Object.create
+          ? function (o, v) {
+              Object.defineProperty(o, 'default', { enumerable: true, value: v });
+            }
+          : function (o, v) {
+              o['default'] = v;
+            });
+      var __importStar =
+        (this && this.__importStar) ||
+        function (mod) {
+          if (mod && mod.__esModule) return mod;
+          var result = {};
+          if (mod != null)
+            for (var k in mod)
+              if (k !== 'default' && Object.hasOwnProperty.call(mod, k))
+                __createBinding(result, mod, k);
+          __setModuleDefault(result, mod);
+          return result;
+        };
+      Object.defineProperty(exports, '__esModule', { value: true });
+      exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = void 0;
+      const path = __importStar(__nccwpck_require__(5622));
+      /**
+       * toPosixPath converts the given path to the posix form. On Windows, \\ will be
+       * replaced with /.
+       *
+       * @param pth. Path to transform.
+       * @return string Posix path.
+       */
+      function toPosixPath(pth) {
+        return pth.replace(/[\\]/g, '/');
+      }
+      exports.toPosixPath = toPosixPath;
+      /**
+       * toWin32Path converts the given path to the win32 form. On Linux, / will be
+       * replaced with \\.
+       *
+       * @param pth. Path to transform.
+       * @return string Win32 path.
+       */
+      function toWin32Path(pth) {
+        return pth.replace(/[/]/g, '\\');
+      }
+      exports.toWin32Path = toWin32Path;
+      /**
+       * toPlatformPath converts the given path to a platform-specific path. It does
+       * this by replacing instances of / and \ with the platform-specific path
+       * separator.
+       *
+       * @param pth The path to platformize.
+       * @return string The platform-specific path.
+       */
+      function toPlatformPath(pth) {
+        return pth.replace(/[/\\]/g, path.sep);
+      }
+      exports.toPlatformPath = toPlatformPath;
+      //# sourceMappingURL=path-utils.js.map
+
+      /***/
+    },
+
+    /***/ 1327: /***/ function (__unused_webpack_module, exports, __nccwpck_require__) {
+      'use strict';
+
+      var __awaiter =
+        (this && this.__awaiter) ||
+        function (thisArg, _arguments, P, generator) {
+          function adopt(value) {
+            return value instanceof P
+              ? value
+              : new P(function (resolve) {
+                  resolve(value);
+                });
+          }
+          return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+              try {
+                step(generator.next(value));
+              } catch (e) {
+                reject(e);
+              }
+            }
+            function rejected(value) {
+              try {
+                step(generator['throw'](value));
+              } catch (e) {
+                reject(e);
+              }
+            }
+            function step(result) {
+              result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+          });
+        };
+      Object.defineProperty(exports, '__esModule', { value: true });
+      exports.summary =
+        exports.markdownSummary =
+        exports.SUMMARY_DOCS_URL =
+        exports.SUMMARY_ENV_VAR =
+          void 0;
+      const os_1 = __nccwpck_require__(2087);
+      const fs_1 = __nccwpck_require__(5747);
+      const { access, appendFile, writeFile } = fs_1.promises;
+      exports.SUMMARY_ENV_VAR = 'GITHUB_STEP_SUMMARY';
+      exports.SUMMARY_DOCS_URL =
+        'https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary';
+      class Summary {
+        constructor() {
+          this._buffer = '';
+        }
+        /**
+         * Finds the summary file path from the environment, rejects if env var is not found or file does not exist
+         * Also checks r/w permissions.
+         *
+         * @returns step summary file path
+         */
+        filePath() {
+          return __awaiter(this, void 0, void 0, function* () {
+            if (this._filePath) {
+              return this._filePath;
+            }
+            const pathFromEnv = process.env[exports.SUMMARY_ENV_VAR];
+            if (!pathFromEnv) {
+              throw new Error(
+                `Unable to find environment variable for $${exports.SUMMARY_ENV_VAR}. Check if your runtime environment supports job summaries.`
+              );
+            }
+            try {
+              yield access(pathFromEnv, fs_1.constants.R_OK | fs_1.constants.W_OK);
+            } catch (_a) {
+              throw new Error(
+                `Unable to access summary file: '${pathFromEnv}'. Check if the file has correct read/write permissions.`
+              );
+            }
+            this._filePath = pathFromEnv;
+            return this._filePath;
+          });
+        }
+        /**
+         * Wraps content in an HTML tag, adding any HTML attributes
+         *
+         * @param {string} tag HTML tag to wrap
+         * @param {string | null} content content within the tag
+         * @param {[attribute: string]: string} attrs key-value list of HTML attributes to add
+         *
+         * @returns {string} content wrapped in HTML element
+         */
+        wrap(tag, content, attrs = {}) {
+          const htmlAttrs = Object.entries(attrs)
+            .map(([key, value]) => ` ${key}="${value}"`)
+            .join('');
+          if (!content) {
+            return `<${tag}${htmlAttrs}>`;
+          }
+          return `<${tag}${htmlAttrs}>${content}</${tag}>`;
+        }
+        /**
+         * Writes text in the buffer to the summary buffer file and empties buffer. Will append by default.
+         *
+         * @param {SummaryWriteOptions} [options] (optional) options for write operation
+         *
+         * @returns {Promise<Summary>} summary instance
+         */
+        write(options) {
+          return __awaiter(this, void 0, void 0, function* () {
+            const overwrite = !!(options === null || options === void 0
+              ? void 0
+              : options.overwrite);
+            const filePath = yield this.filePath();
+            const writeFunc = overwrite ? writeFile : appendFile;
+            yield writeFunc(filePath, this._buffer, { encoding: 'utf8' });
+            return this.emptyBuffer();
+          });
+        }
+        /**
+         * Clears the summary buffer and wipes the summary file
+         *
+         * @returns {Summary} summary instance
+         */
+        clear() {
+          return __awaiter(this, void 0, void 0, function* () {
+            return this.emptyBuffer().write({ overwrite: true });
+          });
+        }
+        /**
+         * Returns the current summary buffer as a string
+         *
+         * @returns {string} string of summary buffer
+         */
+        stringify() {
+          return this._buffer;
+        }
+        /**
+         * If the summary buffer is empty
+         *
+         * @returns {boolen} true if the buffer is empty
+         */
+        isEmptyBuffer() {
+          return this._buffer.length === 0;
+        }
+        /**
+         * Resets the summary buffer without writing to summary file
+         *
+         * @returns {Summary} summary instance
+         */
+        emptyBuffer() {
+          this._buffer = '';
+          return this;
+        }
+        /**
+         * Adds raw text to the summary buffer
+         *
+         * @param {string} text content to add
+         * @param {boolean} [addEOL=false] (optional) append an EOL to the raw text (default: false)
+         *
+         * @returns {Summary} summary instance
+         */
+        addRaw(text, addEOL = false) {
+          this._buffer += text;
+          return addEOL ? this.addEOL() : this;
+        }
+        /**
+         * Adds the operating system-specific end-of-line marker to the buffer
+         *
+         * @returns {Summary} summary instance
+         */
+        addEOL() {
+          return this.addRaw(os_1.EOL);
+        }
+        /**
+         * Adds an HTML codeblock to the summary buffer
+         *
+         * @param {string} code content to render within fenced code block
+         * @param {string} lang (optional) language to syntax highlight code
+         *
+         * @returns {Summary} summary instance
+         */
+        addCodeBlock(code, lang) {
+          const attrs = Object.assign({}, lang && { lang });
+          const element = this.wrap('pre', this.wrap('code', code), attrs);
+          return this.addRaw(element).addEOL();
+        }
+        /**
+         * Adds an HTML list to the summary buffer
+         *
+         * @param {string[]} items list of items to render
+         * @param {boolean} [ordered=false] (optional) if the rendered list should be ordered or not (default: false)
+         *
+         * @returns {Summary} summary instance
+         */
+        addList(items, ordered = false) {
+          const tag = ordered ? 'ol' : 'ul';
+          const listItems = items.map(item => this.wrap('li', item)).join('');
+          const element = this.wrap(tag, listItems);
+          return this.addRaw(element).addEOL();
+        }
+        /**
+         * Adds an HTML table to the summary buffer
+         *
+         * @param {SummaryTableCell[]} rows table rows
+         *
+         * @returns {Summary} summary instance
+         */
+        addTable(rows) {
+          const tableBody = rows
+            .map(row => {
+              const cells = row
+                .map(cell => {
+                  if (typeof cell === 'string') {
+                    return this.wrap('td', cell);
+                  }
+                  const { header, data, colspan, rowspan } = cell;
+                  const tag = header ? 'th' : 'td';
+                  const attrs = Object.assign(
+                    Object.assign({}, colspan && { colspan }),
+                    rowspan && { rowspan }
+                  );
+                  return this.wrap(tag, data, attrs);
+                })
+                .join('');
+              return this.wrap('tr', cells);
+            })
+            .join('');
+          const element = this.wrap('table', tableBody);
+          return this.addRaw(element).addEOL();
+        }
+        /**
+         * Adds a collapsable HTML details element to the summary buffer
+         *
+         * @param {string} label text for the closed state
+         * @param {string} content collapsable content
+         *
+         * @returns {Summary} summary instance
+         */
+        addDetails(label, content) {
+          const element = this.wrap('details', this.wrap('summary', label) + content);
+          return this.addRaw(element).addEOL();
+        }
+        /**
+         * Adds an HTML image tag to the summary buffer
+         *
+         * @param {string} src path to the image you to embed
+         * @param {string} alt text description of the image
+         * @param {SummaryImageOptions} options (optional) addition image attributes
+         *
+         * @returns {Summary} summary instance
+         */
+        addImage(src, alt, options) {
+          const { width, height } = options || {};
+          const attrs = Object.assign(Object.assign({}, width && { width }), height && { height });
+          const element = this.wrap('img', null, Object.assign({ src, alt }, attrs));
+          return this.addRaw(element).addEOL();
+        }
+        /**
+         * Adds an HTML section heading element
+         *
+         * @param {string} text heading text
+         * @param {number | string} [level=1] (optional) the heading level, default: 1
+         *
+         * @returns {Summary} summary instance
+         */
+        addHeading(text, level) {
+          const tag = `h${level}`;
+          const allowedTag = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(tag) ? tag : 'h1';
+          const element = this.wrap(allowedTag, text);
+          return this.addRaw(element).addEOL();
+        }
+        /**
+         * Adds an HTML thematic break (<hr>) to the summary buffer
+         *
+         * @returns {Summary} summary instance
+         */
+        addSeparator() {
+          const element = this.wrap('hr', null);
+          return this.addRaw(element).addEOL();
+        }
+        /**
+         * Adds an HTML line break (<br>) to the summary buffer
+         *
+         * @returns {Summary} summary instance
+         */
+        addBreak() {
+          const element = this.wrap('br', null);
+          return this.addRaw(element).addEOL();
+        }
+        /**
+         * Adds an HTML blockquote to the summary buffer
+         *
+         * @param {string} text quote text
+         * @param {string} cite (optional) citation url
+         *
+         * @returns {Summary} summary instance
+         */
+        addQuote(text, cite) {
+          const attrs = Object.assign({}, cite && { cite });
+          const element = this.wrap('blockquote', text, attrs);
+          return this.addRaw(element).addEOL();
+        }
+        /**
+         * Adds an HTML anchor tag to the summary buffer
+         *
+         * @param {string} text link text/content
+         * @param {string} href hyperlink
+         *
+         * @returns {Summary} summary instance
+         */
+        addLink(text, href) {
+          const element = this.wrap('a', text, { href });
+          return this.addRaw(element).addEOL();
+        }
+      }
+      const _summary = new Summary();
+      /**
+       * @deprecated use `core.summary`
+       */
+      exports.markdownSummary = _summary;
+      exports.summary = _summary;
+      //# sourceMappingURL=summary.js.map
 
       /***/
     },
@@ -400,6 +1166,7 @@
       // We use any as a valid input type
       /* eslint-disable @typescript-eslint/no-explicit-any */
       Object.defineProperty(exports, '__esModule', { value: true });
+      exports.toCommandProperties = exports.toCommandValue = void 0;
       /**
        * Sanitizes an input into a string so it can be passed into issueCommand safely
        * @param input input to sanitize into a string
@@ -413,7 +1180,1567 @@
         return JSON.stringify(input);
       }
       exports.toCommandValue = toCommandValue;
+      /**
+       *
+       * @param annotationProperties
+       * @returns The command properties to send with the actual annotation command
+       * See IssueCommandProperties: https://github.com/actions/runner/blob/main/src/Runner.Worker/ActionCommandManager.cs#L646
+       */
+      function toCommandProperties(annotationProperties) {
+        if (!Object.keys(annotationProperties).length) {
+          return {};
+        }
+        return {
+          title: annotationProperties.title,
+          file: annotationProperties.file,
+          line: annotationProperties.startLine,
+          endLine: annotationProperties.endLine,
+          col: annotationProperties.startColumn,
+          endColumn: annotationProperties.endColumn
+        };
+      }
+      exports.toCommandProperties = toCommandProperties;
       //# sourceMappingURL=utils.js.map
+
+      /***/
+    },
+
+    /***/ 6758: /***/ function (__unused_webpack_module, exports) {
+      'use strict';
+
+      var __awaiter =
+        (this && this.__awaiter) ||
+        function (thisArg, _arguments, P, generator) {
+          function adopt(value) {
+            return value instanceof P
+              ? value
+              : new P(function (resolve) {
+                  resolve(value);
+                });
+          }
+          return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+              try {
+                step(generator.next(value));
+              } catch (e) {
+                reject(e);
+              }
+            }
+            function rejected(value) {
+              try {
+                step(generator['throw'](value));
+              } catch (e) {
+                reject(e);
+              }
+            }
+            function step(result) {
+              result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+          });
+        };
+      Object.defineProperty(exports, '__esModule', { value: true });
+      exports.PersonalAccessTokenCredentialHandler =
+        exports.BearerCredentialHandler =
+        exports.BasicCredentialHandler =
+          void 0;
+      class BasicCredentialHandler {
+        constructor(username, password) {
+          this.username = username;
+          this.password = password;
+        }
+        prepareRequest(options) {
+          if (!options.headers) {
+            throw Error('The request has no headers');
+          }
+          options.headers['Authorization'] = `Basic ${Buffer.from(
+            `${this.username}:${this.password}`
+          ).toString('base64')}`;
+        }
+        // This handler cannot handle 401
+        canHandleAuthentication() {
+          return false;
+        }
+        handleAuthentication() {
+          return __awaiter(this, void 0, void 0, function* () {
+            throw new Error('not implemented');
+          });
+        }
+      }
+      exports.BasicCredentialHandler = BasicCredentialHandler;
+      class BearerCredentialHandler {
+        constructor(token) {
+          this.token = token;
+        }
+        // currently implements pre-authorization
+        // TODO: support preAuth = false where it hooks on 401
+        prepareRequest(options) {
+          if (!options.headers) {
+            throw Error('The request has no headers');
+          }
+          options.headers['Authorization'] = `Bearer ${this.token}`;
+        }
+        // This handler cannot handle 401
+        canHandleAuthentication() {
+          return false;
+        }
+        handleAuthentication() {
+          return __awaiter(this, void 0, void 0, function* () {
+            throw new Error('not implemented');
+          });
+        }
+      }
+      exports.BearerCredentialHandler = BearerCredentialHandler;
+      class PersonalAccessTokenCredentialHandler {
+        constructor(token) {
+          this.token = token;
+        }
+        // currently implements pre-authorization
+        // TODO: support preAuth = false where it hooks on 401
+        prepareRequest(options) {
+          if (!options.headers) {
+            throw Error('The request has no headers');
+          }
+          options.headers['Authorization'] = `Basic ${Buffer.from(`PAT:${this.token}`).toString(
+            'base64'
+          )}`;
+        }
+        // This handler cannot handle 401
+        canHandleAuthentication() {
+          return false;
+        }
+        handleAuthentication() {
+          return __awaiter(this, void 0, void 0, function* () {
+            throw new Error('not implemented');
+          });
+        }
+      }
+      exports.PersonalAccessTokenCredentialHandler = PersonalAccessTokenCredentialHandler;
+      //# sourceMappingURL=auth.js.map
+
+      /***/
+    },
+
+    /***/ 1404: /***/ function (__unused_webpack_module, exports, __nccwpck_require__) {
+      'use strict';
+
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      var __createBinding =
+        (this && this.__createBinding) ||
+        (Object.create
+          ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              Object.defineProperty(o, k2, {
+                enumerable: true,
+                get: function () {
+                  return m[k];
+                }
+              });
+            }
+          : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+            });
+      var __setModuleDefault =
+        (this && this.__setModuleDefault) ||
+        (Object.create
+          ? function (o, v) {
+              Object.defineProperty(o, 'default', { enumerable: true, value: v });
+            }
+          : function (o, v) {
+              o['default'] = v;
+            });
+      var __importStar =
+        (this && this.__importStar) ||
+        function (mod) {
+          if (mod && mod.__esModule) return mod;
+          var result = {};
+          if (mod != null)
+            for (var k in mod)
+              if (k !== 'default' && Object.hasOwnProperty.call(mod, k))
+                __createBinding(result, mod, k);
+          __setModuleDefault(result, mod);
+          return result;
+        };
+      var __awaiter =
+        (this && this.__awaiter) ||
+        function (thisArg, _arguments, P, generator) {
+          function adopt(value) {
+            return value instanceof P
+              ? value
+              : new P(function (resolve) {
+                  resolve(value);
+                });
+          }
+          return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+              try {
+                step(generator.next(value));
+              } catch (e) {
+                reject(e);
+              }
+            }
+            function rejected(value) {
+              try {
+                step(generator['throw'](value));
+              } catch (e) {
+                reject(e);
+              }
+            }
+            function step(result) {
+              result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+          });
+        };
+      Object.defineProperty(exports, '__esModule', { value: true });
+      exports.HttpClient =
+        exports.isHttps =
+        exports.HttpClientResponse =
+        exports.HttpClientError =
+        exports.getProxyUrl =
+        exports.MediaTypes =
+        exports.Headers =
+        exports.HttpCodes =
+          void 0;
+      const http = __importStar(__nccwpck_require__(8605));
+      const https = __importStar(__nccwpck_require__(7211));
+      const pm = __importStar(__nccwpck_require__(2843));
+      const tunnel = __importStar(__nccwpck_require__(4294));
+      var HttpCodes;
+      (function (HttpCodes) {
+        HttpCodes[(HttpCodes['OK'] = 200)] = 'OK';
+        HttpCodes[(HttpCodes['MultipleChoices'] = 300)] = 'MultipleChoices';
+        HttpCodes[(HttpCodes['MovedPermanently'] = 301)] = 'MovedPermanently';
+        HttpCodes[(HttpCodes['ResourceMoved'] = 302)] = 'ResourceMoved';
+        HttpCodes[(HttpCodes['SeeOther'] = 303)] = 'SeeOther';
+        HttpCodes[(HttpCodes['NotModified'] = 304)] = 'NotModified';
+        HttpCodes[(HttpCodes['UseProxy'] = 305)] = 'UseProxy';
+        HttpCodes[(HttpCodes['SwitchProxy'] = 306)] = 'SwitchProxy';
+        HttpCodes[(HttpCodes['TemporaryRedirect'] = 307)] = 'TemporaryRedirect';
+        HttpCodes[(HttpCodes['PermanentRedirect'] = 308)] = 'PermanentRedirect';
+        HttpCodes[(HttpCodes['BadRequest'] = 400)] = 'BadRequest';
+        HttpCodes[(HttpCodes['Unauthorized'] = 401)] = 'Unauthorized';
+        HttpCodes[(HttpCodes['PaymentRequired'] = 402)] = 'PaymentRequired';
+        HttpCodes[(HttpCodes['Forbidden'] = 403)] = 'Forbidden';
+        HttpCodes[(HttpCodes['NotFound'] = 404)] = 'NotFound';
+        HttpCodes[(HttpCodes['MethodNotAllowed'] = 405)] = 'MethodNotAllowed';
+        HttpCodes[(HttpCodes['NotAcceptable'] = 406)] = 'NotAcceptable';
+        HttpCodes[(HttpCodes['ProxyAuthenticationRequired'] = 407)] = 'ProxyAuthenticationRequired';
+        HttpCodes[(HttpCodes['RequestTimeout'] = 408)] = 'RequestTimeout';
+        HttpCodes[(HttpCodes['Conflict'] = 409)] = 'Conflict';
+        HttpCodes[(HttpCodes['Gone'] = 410)] = 'Gone';
+        HttpCodes[(HttpCodes['TooManyRequests'] = 429)] = 'TooManyRequests';
+        HttpCodes[(HttpCodes['InternalServerError'] = 500)] = 'InternalServerError';
+        HttpCodes[(HttpCodes['NotImplemented'] = 501)] = 'NotImplemented';
+        HttpCodes[(HttpCodes['BadGateway'] = 502)] = 'BadGateway';
+        HttpCodes[(HttpCodes['ServiceUnavailable'] = 503)] = 'ServiceUnavailable';
+        HttpCodes[(HttpCodes['GatewayTimeout'] = 504)] = 'GatewayTimeout';
+      })((HttpCodes = exports.HttpCodes || (exports.HttpCodes = {})));
+      var Headers;
+      (function (Headers) {
+        Headers['Accept'] = 'accept';
+        Headers['ContentType'] = 'content-type';
+      })((Headers = exports.Headers || (exports.Headers = {})));
+      var MediaTypes;
+      (function (MediaTypes) {
+        MediaTypes['ApplicationJson'] = 'application/json';
+      })((MediaTypes = exports.MediaTypes || (exports.MediaTypes = {})));
+      /**
+       * Returns the proxy URL, depending upon the supplied url and proxy environment variables.
+       * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
+       */
+      function getProxyUrl(serverUrl) {
+        const proxyUrl = pm.getProxyUrl(new URL(serverUrl));
+        return proxyUrl ? proxyUrl.href : '';
+      }
+      exports.getProxyUrl = getProxyUrl;
+      const HttpRedirectCodes = [
+        HttpCodes.MovedPermanently,
+        HttpCodes.ResourceMoved,
+        HttpCodes.SeeOther,
+        HttpCodes.TemporaryRedirect,
+        HttpCodes.PermanentRedirect
+      ];
+      const HttpResponseRetryCodes = [
+        HttpCodes.BadGateway,
+        HttpCodes.ServiceUnavailable,
+        HttpCodes.GatewayTimeout
+      ];
+      const RetryableHttpVerbs = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
+      const ExponentialBackoffCeiling = 10;
+      const ExponentialBackoffTimeSlice = 5;
+      class HttpClientError extends Error {
+        constructor(message, statusCode) {
+          super(message);
+          this.name = 'HttpClientError';
+          this.statusCode = statusCode;
+          Object.setPrototypeOf(this, HttpClientError.prototype);
+        }
+      }
+      exports.HttpClientError = HttpClientError;
+      class HttpClientResponse {
+        constructor(message) {
+          this.message = message;
+        }
+        readBody() {
+          return __awaiter(this, void 0, void 0, function* () {
+            return new Promise(resolve =>
+              __awaiter(this, void 0, void 0, function* () {
+                let output = Buffer.alloc(0);
+                this.message.on('data', chunk => {
+                  output = Buffer.concat([output, chunk]);
+                });
+                this.message.on('end', () => {
+                  resolve(output.toString());
+                });
+              })
+            );
+          });
+        }
+      }
+      exports.HttpClientResponse = HttpClientResponse;
+      function isHttps(requestUrl) {
+        const parsedUrl = new URL(requestUrl);
+        return parsedUrl.protocol === 'https:';
+      }
+      exports.isHttps = isHttps;
+      class HttpClient {
+        constructor(userAgent, handlers, requestOptions) {
+          this._ignoreSslError = false;
+          this._allowRedirects = true;
+          this._allowRedirectDowngrade = false;
+          this._maxRedirects = 50;
+          this._allowRetries = false;
+          this._maxRetries = 1;
+          this._keepAlive = false;
+          this._disposed = false;
+          this.userAgent = userAgent;
+          this.handlers = handlers || [];
+          this.requestOptions = requestOptions;
+          if (requestOptions) {
+            if (requestOptions.ignoreSslError != null) {
+              this._ignoreSslError = requestOptions.ignoreSslError;
+            }
+            this._socketTimeout = requestOptions.socketTimeout;
+            if (requestOptions.allowRedirects != null) {
+              this._allowRedirects = requestOptions.allowRedirects;
+            }
+            if (requestOptions.allowRedirectDowngrade != null) {
+              this._allowRedirectDowngrade = requestOptions.allowRedirectDowngrade;
+            }
+            if (requestOptions.maxRedirects != null) {
+              this._maxRedirects = Math.max(requestOptions.maxRedirects, 0);
+            }
+            if (requestOptions.keepAlive != null) {
+              this._keepAlive = requestOptions.keepAlive;
+            }
+            if (requestOptions.allowRetries != null) {
+              this._allowRetries = requestOptions.allowRetries;
+            }
+            if (requestOptions.maxRetries != null) {
+              this._maxRetries = requestOptions.maxRetries;
+            }
+          }
+        }
+        options(requestUrl, additionalHeaders) {
+          return __awaiter(this, void 0, void 0, function* () {
+            return this.request('OPTIONS', requestUrl, null, additionalHeaders || {});
+          });
+        }
+        get(requestUrl, additionalHeaders) {
+          return __awaiter(this, void 0, void 0, function* () {
+            return this.request('GET', requestUrl, null, additionalHeaders || {});
+          });
+        }
+        del(requestUrl, additionalHeaders) {
+          return __awaiter(this, void 0, void 0, function* () {
+            return this.request('DELETE', requestUrl, null, additionalHeaders || {});
+          });
+        }
+        post(requestUrl, data, additionalHeaders) {
+          return __awaiter(this, void 0, void 0, function* () {
+            return this.request('POST', requestUrl, data, additionalHeaders || {});
+          });
+        }
+        patch(requestUrl, data, additionalHeaders) {
+          return __awaiter(this, void 0, void 0, function* () {
+            return this.request('PATCH', requestUrl, data, additionalHeaders || {});
+          });
+        }
+        put(requestUrl, data, additionalHeaders) {
+          return __awaiter(this, void 0, void 0, function* () {
+            return this.request('PUT', requestUrl, data, additionalHeaders || {});
+          });
+        }
+        head(requestUrl, additionalHeaders) {
+          return __awaiter(this, void 0, void 0, function* () {
+            return this.request('HEAD', requestUrl, null, additionalHeaders || {});
+          });
+        }
+        sendStream(verb, requestUrl, stream, additionalHeaders) {
+          return __awaiter(this, void 0, void 0, function* () {
+            return this.request(verb, requestUrl, stream, additionalHeaders);
+          });
+        }
+        /**
+         * Gets a typed object from an endpoint
+         * Be aware that not found returns a null.  Other errors (4xx, 5xx) reject the promise
+         */
+        getJson(requestUrl, additionalHeaders = {}) {
+          return __awaiter(this, void 0, void 0, function* () {
+            additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
+              additionalHeaders,
+              Headers.Accept,
+              MediaTypes.ApplicationJson
+            );
+            const res = yield this.get(requestUrl, additionalHeaders);
+            return this._processResponse(res, this.requestOptions);
+          });
+        }
+        postJson(requestUrl, obj, additionalHeaders = {}) {
+          return __awaiter(this, void 0, void 0, function* () {
+            const data = JSON.stringify(obj, null, 2);
+            additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
+              additionalHeaders,
+              Headers.Accept,
+              MediaTypes.ApplicationJson
+            );
+            additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(
+              additionalHeaders,
+              Headers.ContentType,
+              MediaTypes.ApplicationJson
+            );
+            const res = yield this.post(requestUrl, data, additionalHeaders);
+            return this._processResponse(res, this.requestOptions);
+          });
+        }
+        putJson(requestUrl, obj, additionalHeaders = {}) {
+          return __awaiter(this, void 0, void 0, function* () {
+            const data = JSON.stringify(obj, null, 2);
+            additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
+              additionalHeaders,
+              Headers.Accept,
+              MediaTypes.ApplicationJson
+            );
+            additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(
+              additionalHeaders,
+              Headers.ContentType,
+              MediaTypes.ApplicationJson
+            );
+            const res = yield this.put(requestUrl, data, additionalHeaders);
+            return this._processResponse(res, this.requestOptions);
+          });
+        }
+        patchJson(requestUrl, obj, additionalHeaders = {}) {
+          return __awaiter(this, void 0, void 0, function* () {
+            const data = JSON.stringify(obj, null, 2);
+            additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
+              additionalHeaders,
+              Headers.Accept,
+              MediaTypes.ApplicationJson
+            );
+            additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(
+              additionalHeaders,
+              Headers.ContentType,
+              MediaTypes.ApplicationJson
+            );
+            const res = yield this.patch(requestUrl, data, additionalHeaders);
+            return this._processResponse(res, this.requestOptions);
+          });
+        }
+        /**
+         * Makes a raw http request.
+         * All other methods such as get, post, patch, and request ultimately call this.
+         * Prefer get, del, post and patch
+         */
+        request(verb, requestUrl, data, headers) {
+          return __awaiter(this, void 0, void 0, function* () {
+            if (this._disposed) {
+              throw new Error('Client has already been disposed.');
+            }
+            const parsedUrl = new URL(requestUrl);
+            let info = this._prepareRequest(verb, parsedUrl, headers);
+            // Only perform retries on reads since writes may not be idempotent.
+            const maxTries =
+              this._allowRetries && RetryableHttpVerbs.includes(verb) ? this._maxRetries + 1 : 1;
+            let numTries = 0;
+            let response;
+            do {
+              response = yield this.requestRaw(info, data);
+              // Check if it's an authentication challenge
+              if (
+                response &&
+                response.message &&
+                response.message.statusCode === HttpCodes.Unauthorized
+              ) {
+                let authenticationHandler;
+                for (const handler of this.handlers) {
+                  if (handler.canHandleAuthentication(response)) {
+                    authenticationHandler = handler;
+                    break;
+                  }
+                }
+                if (authenticationHandler) {
+                  return authenticationHandler.handleAuthentication(this, info, data);
+                } else {
+                  // We have received an unauthorized response but have no handlers to handle it.
+                  // Let the response return to the caller.
+                  return response;
+                }
+              }
+              let redirectsRemaining = this._maxRedirects;
+              while (
+                response.message.statusCode &&
+                HttpRedirectCodes.includes(response.message.statusCode) &&
+                this._allowRedirects &&
+                redirectsRemaining > 0
+              ) {
+                const redirectUrl = response.message.headers['location'];
+                if (!redirectUrl) {
+                  // if there's no location to redirect to, we won't
+                  break;
+                }
+                const parsedRedirectUrl = new URL(redirectUrl);
+                if (
+                  parsedUrl.protocol === 'https:' &&
+                  parsedUrl.protocol !== parsedRedirectUrl.protocol &&
+                  !this._allowRedirectDowngrade
+                ) {
+                  throw new Error(
+                    'Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.'
+                  );
+                }
+                // we need to finish reading the response before reassigning response
+                // which will leak the open socket.
+                yield response.readBody();
+                // strip authorization header if redirected to a different hostname
+                if (parsedRedirectUrl.hostname !== parsedUrl.hostname) {
+                  for (const header in headers) {
+                    // header names are case insensitive
+                    if (header.toLowerCase() === 'authorization') {
+                      delete headers[header];
+                    }
+                  }
+                }
+                // let's make the request with the new redirectUrl
+                info = this._prepareRequest(verb, parsedRedirectUrl, headers);
+                response = yield this.requestRaw(info, data);
+                redirectsRemaining--;
+              }
+              if (
+                !response.message.statusCode ||
+                !HttpResponseRetryCodes.includes(response.message.statusCode)
+              ) {
+                // If not a retry code, return immediately instead of retrying
+                return response;
+              }
+              numTries += 1;
+              if (numTries < maxTries) {
+                yield response.readBody();
+                yield this._performExponentialBackoff(numTries);
+              }
+            } while (numTries < maxTries);
+            return response;
+          });
+        }
+        /**
+         * Needs to be called if keepAlive is set to true in request options.
+         */
+        dispose() {
+          if (this._agent) {
+            this._agent.destroy();
+          }
+          this._disposed = true;
+        }
+        /**
+         * Raw request.
+         * @param info
+         * @param data
+         */
+        requestRaw(info, data) {
+          return __awaiter(this, void 0, void 0, function* () {
+            return new Promise((resolve, reject) => {
+              function callbackForResult(err, res) {
+                if (err) {
+                  reject(err);
+                } else if (!res) {
+                  // If `err` is not passed, then `res` must be passed.
+                  reject(new Error('Unknown error'));
+                } else {
+                  resolve(res);
+                }
+              }
+              this.requestRawWithCallback(info, data, callbackForResult);
+            });
+          });
+        }
+        /**
+         * Raw request with callback.
+         * @param info
+         * @param data
+         * @param onResult
+         */
+        requestRawWithCallback(info, data, onResult) {
+          if (typeof data === 'string') {
+            if (!info.options.headers) {
+              info.options.headers = {};
+            }
+            info.options.headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
+          }
+          let callbackCalled = false;
+          function handleResult(err, res) {
+            if (!callbackCalled) {
+              callbackCalled = true;
+              onResult(err, res);
+            }
+          }
+          const req = info.httpModule.request(info.options, msg => {
+            const res = new HttpClientResponse(msg);
+            handleResult(undefined, res);
+          });
+          let socket;
+          req.on('socket', sock => {
+            socket = sock;
+          });
+          // If we ever get disconnected, we want the socket to timeout eventually
+          req.setTimeout(this._socketTimeout || 3 * 60000, () => {
+            if (socket) {
+              socket.end();
+            }
+            handleResult(new Error(`Request timeout: ${info.options.path}`));
+          });
+          req.on('error', function (err) {
+            // err has statusCode property
+            // res should have headers
+            handleResult(err);
+          });
+          if (data && typeof data === 'string') {
+            req.write(data, 'utf8');
+          }
+          if (data && typeof data !== 'string') {
+            data.on('close', function () {
+              req.end();
+            });
+            data.pipe(req);
+          } else {
+            req.end();
+          }
+        }
+        /**
+         * Gets an http agent. This function is useful when you need an http agent that handles
+         * routing through a proxy server - depending upon the url and proxy environment variables.
+         * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
+         */
+        getAgent(serverUrl) {
+          const parsedUrl = new URL(serverUrl);
+          return this._getAgent(parsedUrl);
+        }
+        _prepareRequest(method, requestUrl, headers) {
+          const info = {};
+          info.parsedUrl = requestUrl;
+          const usingSsl = info.parsedUrl.protocol === 'https:';
+          info.httpModule = usingSsl ? https : http;
+          const defaultPort = usingSsl ? 443 : 80;
+          info.options = {};
+          info.options.host = info.parsedUrl.hostname;
+          info.options.port = info.parsedUrl.port ? parseInt(info.parsedUrl.port) : defaultPort;
+          info.options.path = (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
+          info.options.method = method;
+          info.options.headers = this._mergeHeaders(headers);
+          if (this.userAgent != null) {
+            info.options.headers['user-agent'] = this.userAgent;
+          }
+          info.options.agent = this._getAgent(info.parsedUrl);
+          // gives handlers an opportunity to participate
+          if (this.handlers) {
+            for (const handler of this.handlers) {
+              handler.prepareRequest(info.options);
+            }
+          }
+          return info;
+        }
+        _mergeHeaders(headers) {
+          if (this.requestOptions && this.requestOptions.headers) {
+            return Object.assign(
+              {},
+              lowercaseKeys(this.requestOptions.headers),
+              lowercaseKeys(headers || {})
+            );
+          }
+          return lowercaseKeys(headers || {});
+        }
+        _getExistingOrDefaultHeader(additionalHeaders, header, _default) {
+          let clientHeader;
+          if (this.requestOptions && this.requestOptions.headers) {
+            clientHeader = lowercaseKeys(this.requestOptions.headers)[header];
+          }
+          return additionalHeaders[header] || clientHeader || _default;
+        }
+        _getAgent(parsedUrl) {
+          let agent;
+          const proxyUrl = pm.getProxyUrl(parsedUrl);
+          const useProxy = proxyUrl && proxyUrl.hostname;
+          if (this._keepAlive && useProxy) {
+            agent = this._proxyAgent;
+          }
+          if (this._keepAlive && !useProxy) {
+            agent = this._agent;
+          }
+          // if agent is already assigned use that agent.
+          if (agent) {
+            return agent;
+          }
+          const usingSsl = parsedUrl.protocol === 'https:';
+          let maxSockets = 100;
+          if (this.requestOptions) {
+            maxSockets = this.requestOptions.maxSockets || http.globalAgent.maxSockets;
+          }
+          // This is `useProxy` again, but we need to check `proxyURl` directly for TypeScripts's flow analysis.
+          if (proxyUrl && proxyUrl.hostname) {
+            const agentOptions = {
+              maxSockets,
+              keepAlive: this._keepAlive,
+              proxy: Object.assign(
+                Object.assign(
+                  {},
+                  (proxyUrl.username || proxyUrl.password) && {
+                    proxyAuth: `${proxyUrl.username}:${proxyUrl.password}`
+                  }
+                ),
+                { host: proxyUrl.hostname, port: proxyUrl.port }
+              )
+            };
+            let tunnelAgent;
+            const overHttps = proxyUrl.protocol === 'https:';
+            if (usingSsl) {
+              tunnelAgent = overHttps ? tunnel.httpsOverHttps : tunnel.httpsOverHttp;
+            } else {
+              tunnelAgent = overHttps ? tunnel.httpOverHttps : tunnel.httpOverHttp;
+            }
+            agent = tunnelAgent(agentOptions);
+            this._proxyAgent = agent;
+          }
+          // if reusing agent across request and tunneling agent isn't assigned create a new agent
+          if (this._keepAlive && !agent) {
+            const options = { keepAlive: this._keepAlive, maxSockets };
+            agent = usingSsl ? new https.Agent(options) : new http.Agent(options);
+            this._agent = agent;
+          }
+          // if not using private agent and tunnel agent isn't setup then use global agent
+          if (!agent) {
+            agent = usingSsl ? https.globalAgent : http.globalAgent;
+          }
+          if (usingSsl && this._ignoreSslError) {
+            // we don't want to set NODE_TLS_REJECT_UNAUTHORIZED=0 since that will affect request for entire process
+            // http.RequestOptions doesn't expose a way to modify RequestOptions.agent.options
+            // we have to cast it to any and change it directly
+            agent.options = Object.assign(agent.options || {}, {
+              rejectUnauthorized: false
+            });
+          }
+          return agent;
+        }
+        _performExponentialBackoff(retryNumber) {
+          return __awaiter(this, void 0, void 0, function* () {
+            retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
+            const ms = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
+            return new Promise(resolve => setTimeout(() => resolve(), ms));
+          });
+        }
+        _processResponse(res, options) {
+          return __awaiter(this, void 0, void 0, function* () {
+            return new Promise((resolve, reject) =>
+              __awaiter(this, void 0, void 0, function* () {
+                const statusCode = res.message.statusCode || 0;
+                const response = {
+                  statusCode,
+                  result: null,
+                  headers: {}
+                };
+                // not found leads to null obj returned
+                if (statusCode === HttpCodes.NotFound) {
+                  resolve(response);
+                }
+                // get the result from the body
+                function dateTimeDeserializer(key, value) {
+                  if (typeof value === 'string') {
+                    const a = new Date(value);
+                    if (!isNaN(a.valueOf())) {
+                      return a;
+                    }
+                  }
+                  return value;
+                }
+                let obj;
+                let contents;
+                try {
+                  contents = yield res.readBody();
+                  if (contents && contents.length > 0) {
+                    if (options && options.deserializeDates) {
+                      obj = JSON.parse(contents, dateTimeDeserializer);
+                    } else {
+                      obj = JSON.parse(contents);
+                    }
+                    response.result = obj;
+                  }
+                  response.headers = res.message.headers;
+                } catch (err) {
+                  // Invalid resource (contents not json);  leaving result obj null
+                }
+                // note that 3xx redirects are handled by the http layer.
+                if (statusCode > 299) {
+                  let msg;
+                  // if exception/error in body, attempt to get better error
+                  if (obj && obj.message) {
+                    msg = obj.message;
+                  } else if (contents && contents.length > 0) {
+                    // it may be the case that the exception is in the body message as string
+                    msg = contents;
+                  } else {
+                    msg = `Failed request: (${statusCode})`;
+                  }
+                  const err = new HttpClientError(msg, statusCode);
+                  err.result = response.result;
+                  reject(err);
+                } else {
+                  resolve(response);
+                }
+              })
+            );
+          });
+        }
+      }
+      exports.HttpClient = HttpClient;
+      const lowercaseKeys = obj =>
+        Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
+      //# sourceMappingURL=index.js.map
+
+      /***/
+    },
+
+    /***/ 2843: /***/ (__unused_webpack_module, exports) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', { value: true });
+      exports.checkBypass = exports.getProxyUrl = void 0;
+      function getProxyUrl(reqUrl) {
+        const usingSsl = reqUrl.protocol === 'https:';
+        if (checkBypass(reqUrl)) {
+          return undefined;
+        }
+        const proxyVar = (() => {
+          if (usingSsl) {
+            return process.env['https_proxy'] || process.env['HTTPS_PROXY'];
+          } else {
+            return process.env['http_proxy'] || process.env['HTTP_PROXY'];
+          }
+        })();
+        if (proxyVar) {
+          return new URL(proxyVar);
+        } else {
+          return undefined;
+        }
+      }
+      exports.getProxyUrl = getProxyUrl;
+      function checkBypass(reqUrl) {
+        if (!reqUrl.hostname) {
+          return false;
+        }
+        const noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
+        if (!noProxy) {
+          return false;
+        }
+        // Determine the request port
+        let reqPort;
+        if (reqUrl.port) {
+          reqPort = Number(reqUrl.port);
+        } else if (reqUrl.protocol === 'http:') {
+          reqPort = 80;
+        } else if (reqUrl.protocol === 'https:') {
+          reqPort = 443;
+        }
+        // Format the request hostname and hostname with port
+        const upperReqHosts = [reqUrl.hostname.toUpperCase()];
+        if (typeof reqPort === 'number') {
+          upperReqHosts.push(`${upperReqHosts[0]}:${reqPort}`);
+        }
+        // Compare request host against noproxy
+        for (const upperNoProxyItem of noProxy
+          .split(',')
+          .map(x => x.trim().toUpperCase())
+          .filter(x => x)) {
+          if (upperReqHosts.some(x => x === upperNoProxyItem)) {
+            return true;
+          }
+        }
+        return false;
+      }
+      exports.checkBypass = checkBypass;
+      //# sourceMappingURL=proxy.js.map
+
+      /***/
+    },
+
+    /***/ 8974: /***/ (__unused_webpack_module, exports, __nccwpck_require__) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      Object.defineProperty(exports, 'v1', {
+        enumerable: true,
+        get: function () {
+          return _v.default;
+        }
+      });
+      Object.defineProperty(exports, 'v3', {
+        enumerable: true,
+        get: function () {
+          return _v2.default;
+        }
+      });
+      Object.defineProperty(exports, 'v4', {
+        enumerable: true,
+        get: function () {
+          return _v3.default;
+        }
+      });
+      Object.defineProperty(exports, 'v5', {
+        enumerable: true,
+        get: function () {
+          return _v4.default;
+        }
+      });
+      Object.defineProperty(exports, 'NIL', {
+        enumerable: true,
+        get: function () {
+          return _nil.default;
+        }
+      });
+      Object.defineProperty(exports, 'version', {
+        enumerable: true,
+        get: function () {
+          return _version.default;
+        }
+      });
+      Object.defineProperty(exports, 'validate', {
+        enumerable: true,
+        get: function () {
+          return _validate.default;
+        }
+      });
+      Object.defineProperty(exports, 'stringify', {
+        enumerable: true,
+        get: function () {
+          return _stringify.default;
+        }
+      });
+      Object.defineProperty(exports, 'parse', {
+        enumerable: true,
+        get: function () {
+          return _parse.default;
+        }
+      });
+
+      var _v = _interopRequireDefault(__nccwpck_require__(1595));
+
+      var _v2 = _interopRequireDefault(__nccwpck_require__(6993));
+
+      var _v3 = _interopRequireDefault(__nccwpck_require__(1472));
+
+      var _v4 = _interopRequireDefault(__nccwpck_require__(6217));
+
+      var _nil = _interopRequireDefault(__nccwpck_require__(2381));
+
+      var _version = _interopRequireDefault(__nccwpck_require__(427));
+
+      var _validate = _interopRequireDefault(__nccwpck_require__(2609));
+
+      var _stringify = _interopRequireDefault(__nccwpck_require__(1458));
+
+      var _parse = _interopRequireDefault(__nccwpck_require__(6385));
+
+      function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+
+      /***/
+    },
+
+    /***/ 5842: /***/ (__unused_webpack_module, exports, __nccwpck_require__) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = void 0;
+
+      var _crypto = _interopRequireDefault(__nccwpck_require__(6417));
+
+      function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+
+      function md5(bytes) {
+        if (Array.isArray(bytes)) {
+          bytes = Buffer.from(bytes);
+        } else if (typeof bytes === 'string') {
+          bytes = Buffer.from(bytes, 'utf8');
+        }
+
+        return _crypto.default.createHash('md5').update(bytes).digest();
+      }
+
+      var _default = md5;
+      exports.default = _default;
+
+      /***/
+    },
+
+    /***/ 2381: /***/ (__unused_webpack_module, exports) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = void 0;
+      var _default = '00000000-0000-0000-0000-000000000000';
+      exports.default = _default;
+
+      /***/
+    },
+
+    /***/ 6385: /***/ (__unused_webpack_module, exports, __nccwpck_require__) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = void 0;
+
+      var _validate = _interopRequireDefault(__nccwpck_require__(2609));
+
+      function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+
+      function parse(uuid) {
+        if (!(0, _validate.default)(uuid)) {
+          throw TypeError('Invalid UUID');
+        }
+
+        let v;
+        const arr = new Uint8Array(16); // Parse ########-....-....-....-............
+
+        arr[0] = (v = parseInt(uuid.slice(0, 8), 16)) >>> 24;
+        arr[1] = (v >>> 16) & 0xff;
+        arr[2] = (v >>> 8) & 0xff;
+        arr[3] = v & 0xff; // Parse ........-####-....-....-............
+
+        arr[4] = (v = parseInt(uuid.slice(9, 13), 16)) >>> 8;
+        arr[5] = v & 0xff; // Parse ........-....-####-....-............
+
+        arr[6] = (v = parseInt(uuid.slice(14, 18), 16)) >>> 8;
+        arr[7] = v & 0xff; // Parse ........-....-....-####-............
+
+        arr[8] = (v = parseInt(uuid.slice(19, 23), 16)) >>> 8;
+        arr[9] = v & 0xff; // Parse ........-....-....-....-############
+        // (Use "/" to avoid 32-bit truncation when bit-shifting high-order bytes)
+
+        arr[10] = ((v = parseInt(uuid.slice(24, 36), 16)) / 0x10000000000) & 0xff;
+        arr[11] = (v / 0x100000000) & 0xff;
+        arr[12] = (v >>> 24) & 0xff;
+        arr[13] = (v >>> 16) & 0xff;
+        arr[14] = (v >>> 8) & 0xff;
+        arr[15] = v & 0xff;
+        return arr;
+      }
+
+      var _default = parse;
+      exports.default = _default;
+
+      /***/
+    },
+
+    /***/ 6230: /***/ (__unused_webpack_module, exports) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = void 0;
+      var _default =
+        /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+      exports.default = _default;
+
+      /***/
+    },
+
+    /***/ 9784: /***/ (__unused_webpack_module, exports, __nccwpck_require__) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = rng;
+
+      var _crypto = _interopRequireDefault(__nccwpck_require__(6417));
+
+      function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+
+      const rnds8Pool = new Uint8Array(256); // # of random values to pre-allocate
+
+      let poolPtr = rnds8Pool.length;
+
+      function rng() {
+        if (poolPtr > rnds8Pool.length - 16) {
+          _crypto.default.randomFillSync(rnds8Pool);
+
+          poolPtr = 0;
+        }
+
+        return rnds8Pool.slice(poolPtr, (poolPtr += 16));
+      }
+
+      /***/
+    },
+
+    /***/ 8844: /***/ (__unused_webpack_module, exports, __nccwpck_require__) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = void 0;
+
+      var _crypto = _interopRequireDefault(__nccwpck_require__(6417));
+
+      function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+
+      function sha1(bytes) {
+        if (Array.isArray(bytes)) {
+          bytes = Buffer.from(bytes);
+        } else if (typeof bytes === 'string') {
+          bytes = Buffer.from(bytes, 'utf8');
+        }
+
+        return _crypto.default.createHash('sha1').update(bytes).digest();
+      }
+
+      var _default = sha1;
+      exports.default = _default;
+
+      /***/
+    },
+
+    /***/ 1458: /***/ (__unused_webpack_module, exports, __nccwpck_require__) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = void 0;
+
+      var _validate = _interopRequireDefault(__nccwpck_require__(2609));
+
+      function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+
+      /**
+       * Convert array of 16 byte values to UUID string format of the form:
+       * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+       */
+      const byteToHex = [];
+
+      for (let i = 0; i < 256; ++i) {
+        byteToHex.push((i + 0x100).toString(16).substr(1));
+      }
+
+      function stringify(arr, offset = 0) {
+        // Note: Be careful editing this code!  It's been tuned for performance
+        // and works in ways you may not expect. See https://github.com/uuidjs/uuid/pull/434
+        const uuid = (
+          byteToHex[arr[offset + 0]] +
+          byteToHex[arr[offset + 1]] +
+          byteToHex[arr[offset + 2]] +
+          byteToHex[arr[offset + 3]] +
+          '-' +
+          byteToHex[arr[offset + 4]] +
+          byteToHex[arr[offset + 5]] +
+          '-' +
+          byteToHex[arr[offset + 6]] +
+          byteToHex[arr[offset + 7]] +
+          '-' +
+          byteToHex[arr[offset + 8]] +
+          byteToHex[arr[offset + 9]] +
+          '-' +
+          byteToHex[arr[offset + 10]] +
+          byteToHex[arr[offset + 11]] +
+          byteToHex[arr[offset + 12]] +
+          byteToHex[arr[offset + 13]] +
+          byteToHex[arr[offset + 14]] +
+          byteToHex[arr[offset + 15]]
+        ).toLowerCase(); // Consistency check for valid UUID.  If this throws, it's likely due to one
+        // of the following:
+        // - One or more input array values don't map to a hex octet (leading to
+        // "undefined" in the uuid)
+        // - Invalid input values for the RFC `version` or `variant` fields
+
+        if (!(0, _validate.default)(uuid)) {
+          throw TypeError('Stringified UUID is invalid');
+        }
+
+        return uuid;
+      }
+
+      var _default = stringify;
+      exports.default = _default;
+
+      /***/
+    },
+
+    /***/ 1595: /***/ (__unused_webpack_module, exports, __nccwpck_require__) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = void 0;
+
+      var _rng = _interopRequireDefault(__nccwpck_require__(9784));
+
+      var _stringify = _interopRequireDefault(__nccwpck_require__(1458));
+
+      function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+
+      // **`v1()` - Generate time-based UUID**
+      //
+      // Inspired by https://github.com/LiosK/UUID.js
+      // and http://docs.python.org/library/uuid.html
+      let _nodeId;
+
+      let _clockseq; // Previous uuid creation time
+
+      let _lastMSecs = 0;
+      let _lastNSecs = 0; // See https://github.com/uuidjs/uuid for API details
+
+      function v1(options, buf, offset) {
+        let i = (buf && offset) || 0;
+        const b = buf || new Array(16);
+        options = options || {};
+        let node = options.node || _nodeId;
+        let clockseq = options.clockseq !== undefined ? options.clockseq : _clockseq; // node and clockseq need to be initialized to random values if they're not
+        // specified.  We do this lazily to minimize issues related to insufficient
+        // system entropy.  See #189
+
+        if (node == null || clockseq == null) {
+          const seedBytes = options.random || (options.rng || _rng.default)();
+
+          if (node == null) {
+            // Per 4.5, create and 48-bit node id, (47 random bits + multicast bit = 1)
+            node = _nodeId = [
+              seedBytes[0] | 0x01,
+              seedBytes[1],
+              seedBytes[2],
+              seedBytes[3],
+              seedBytes[4],
+              seedBytes[5]
+            ];
+          }
+
+          if (clockseq == null) {
+            // Per 4.2.2, randomize (14 bit) clockseq
+            clockseq = _clockseq = ((seedBytes[6] << 8) | seedBytes[7]) & 0x3fff;
+          }
+        } // UUID timestamps are 100 nano-second units since the Gregorian epoch,
+        // (1582-10-15 00:00).  JSNumbers aren't precise enough for this, so
+        // time is handled internally as 'msecs' (integer milliseconds) and 'nsecs'
+        // (100-nanoseconds offset from msecs) since unix epoch, 1970-01-01 00:00.
+
+        let msecs = options.msecs !== undefined ? options.msecs : Date.now(); // Per 4.2.1.2, use count of uuid's generated during the current clock
+        // cycle to simulate higher resolution clock
+
+        let nsecs = options.nsecs !== undefined ? options.nsecs : _lastNSecs + 1; // Time since last uuid creation (in msecs)
+
+        const dt = msecs - _lastMSecs + (nsecs - _lastNSecs) / 10000; // Per 4.2.1.2, Bump clockseq on clock regression
+
+        if (dt < 0 && options.clockseq === undefined) {
+          clockseq = (clockseq + 1) & 0x3fff;
+        } // Reset nsecs if clock regresses (new clockseq) or we've moved onto a new
+        // time interval
+
+        if ((dt < 0 || msecs > _lastMSecs) && options.nsecs === undefined) {
+          nsecs = 0;
+        } // Per 4.2.1.2 Throw error if too many uuids are requested
+
+        if (nsecs >= 10000) {
+          throw new Error("uuid.v1(): Can't create more than 10M uuids/sec");
+        }
+
+        _lastMSecs = msecs;
+        _lastNSecs = nsecs;
+        _clockseq = clockseq; // Per 4.1.4 - Convert from unix epoch to Gregorian epoch
+
+        msecs += 12219292800000; // `time_low`
+
+        const tl = ((msecs & 0xfffffff) * 10000 + nsecs) % 0x100000000;
+        b[i++] = (tl >>> 24) & 0xff;
+        b[i++] = (tl >>> 16) & 0xff;
+        b[i++] = (tl >>> 8) & 0xff;
+        b[i++] = tl & 0xff; // `time_mid`
+
+        const tmh = ((msecs / 0x100000000) * 10000) & 0xfffffff;
+        b[i++] = (tmh >>> 8) & 0xff;
+        b[i++] = tmh & 0xff; // `time_high_and_version`
+
+        b[i++] = ((tmh >>> 24) & 0xf) | 0x10; // include version
+
+        b[i++] = (tmh >>> 16) & 0xff; // `clock_seq_hi_and_reserved` (Per 4.2.2 - include variant)
+
+        b[i++] = (clockseq >>> 8) | 0x80; // `clock_seq_low`
+
+        b[i++] = clockseq & 0xff; // `node`
+
+        for (let n = 0; n < 6; ++n) {
+          b[i + n] = node[n];
+        }
+
+        return buf || (0, _stringify.default)(b);
+      }
+
+      var _default = v1;
+      exports.default = _default;
+
+      /***/
+    },
+
+    /***/ 6993: /***/ (__unused_webpack_module, exports, __nccwpck_require__) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = void 0;
+
+      var _v = _interopRequireDefault(__nccwpck_require__(5920));
+
+      var _md = _interopRequireDefault(__nccwpck_require__(5842));
+
+      function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+
+      const v3 = (0, _v.default)('v3', 0x30, _md.default);
+      var _default = v3;
+      exports.default = _default;
+
+      /***/
+    },
+
+    /***/ 5920: /***/ (__unused_webpack_module, exports, __nccwpck_require__) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = _default;
+      exports.URL = exports.DNS = void 0;
+
+      var _stringify = _interopRequireDefault(__nccwpck_require__(1458));
+
+      var _parse = _interopRequireDefault(__nccwpck_require__(6385));
+
+      function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+
+      function stringToBytes(str) {
+        str = unescape(encodeURIComponent(str)); // UTF8 escape
+
+        const bytes = [];
+
+        for (let i = 0; i < str.length; ++i) {
+          bytes.push(str.charCodeAt(i));
+        }
+
+        return bytes;
+      }
+
+      const DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+      exports.DNS = DNS;
+      const URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
+      exports.URL = URL;
+
+      function _default(name, version, hashfunc) {
+        function generateUUID(value, namespace, buf, offset) {
+          if (typeof value === 'string') {
+            value = stringToBytes(value);
+          }
+
+          if (typeof namespace === 'string') {
+            namespace = (0, _parse.default)(namespace);
+          }
+
+          if (namespace.length !== 16) {
+            throw TypeError('Namespace must be array-like (16 iterable integer values, 0-255)');
+          } // Compute hash of namespace and value, Per 4.3
+          // Future: Use spread syntax when supported on all platforms, e.g. `bytes =
+          // hashfunc([...namespace, ... value])`
+
+          let bytes = new Uint8Array(16 + value.length);
+          bytes.set(namespace);
+          bytes.set(value, namespace.length);
+          bytes = hashfunc(bytes);
+          bytes[6] = (bytes[6] & 0x0f) | version;
+          bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+          if (buf) {
+            offset = offset || 0;
+
+            for (let i = 0; i < 16; ++i) {
+              buf[offset + i] = bytes[i];
+            }
+
+            return buf;
+          }
+
+          return (0, _stringify.default)(bytes);
+        } // Function#name is not settable on some platforms (#270)
+
+        try {
+          generateUUID.name = name; // eslint-disable-next-line no-empty
+        } catch (err) {} // For CommonJS default export support
+
+        generateUUID.DNS = DNS;
+        generateUUID.URL = URL;
+        return generateUUID;
+      }
+
+      /***/
+    },
+
+    /***/ 1472: /***/ (__unused_webpack_module, exports, __nccwpck_require__) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = void 0;
+
+      var _rng = _interopRequireDefault(__nccwpck_require__(9784));
+
+      var _stringify = _interopRequireDefault(__nccwpck_require__(1458));
+
+      function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+
+      function v4(options, buf, offset) {
+        options = options || {};
+
+        const rnds = options.random || (options.rng || _rng.default)(); // Per 4.4, set bits for version and `clock_seq_hi_and_reserved`
+
+        rnds[6] = (rnds[6] & 0x0f) | 0x40;
+        rnds[8] = (rnds[8] & 0x3f) | 0x80; // Copy bytes to buffer, if provided
+
+        if (buf) {
+          offset = offset || 0;
+
+          for (let i = 0; i < 16; ++i) {
+            buf[offset + i] = rnds[i];
+          }
+
+          return buf;
+        }
+
+        return (0, _stringify.default)(rnds);
+      }
+
+      var _default = v4;
+      exports.default = _default;
+
+      /***/
+    },
+
+    /***/ 6217: /***/ (__unused_webpack_module, exports, __nccwpck_require__) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = void 0;
+
+      var _v = _interopRequireDefault(__nccwpck_require__(5920));
+
+      var _sha = _interopRequireDefault(__nccwpck_require__(8844));
+
+      function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+
+      const v5 = (0, _v.default)('v5', 0x50, _sha.default);
+      var _default = v5;
+      exports.default = _default;
+
+      /***/
+    },
+
+    /***/ 2609: /***/ (__unused_webpack_module, exports, __nccwpck_require__) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = void 0;
+
+      var _regex = _interopRequireDefault(__nccwpck_require__(6230));
+
+      function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+
+      function validate(uuid) {
+        return typeof uuid === 'string' && _regex.default.test(uuid);
+      }
+
+      var _default = validate;
+      exports.default = _default;
+
+      /***/
+    },
+
+    /***/ 427: /***/ (__unused_webpack_module, exports, __nccwpck_require__) => {
+      'use strict';
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = void 0;
+
+      var _validate = _interopRequireDefault(__nccwpck_require__(2609));
+
+      function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+
+      function version(uuid) {
+        if (!(0, _validate.default)(uuid)) {
+          throw TypeError('Invalid UUID');
+        }
+
+        return parseInt(uuid.substr(14, 1), 16);
+      }
+
+      var _default = version;
+      exports.default = _default;
 
       /***/
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@actions/core": "^1.2.6",
+        "@actions/core": "^1.10.0",
         "@actions/exec": "^1.0.1",
         "@actions/io": "^1.1.0",
         "@martijnhols/actions-cache": "^1.1.3"
@@ -22,9 +22,29 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
-      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "dependencies": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@actions/core/node_modules/@actions/http-client": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+      "dependencies": {
+        "tunnel": "^0.0.6"
+      }
+    },
+    "node_modules/@actions/core/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/@actions/exec": {
       "version": "1.0.4",
@@ -1181,9 +1201,28 @@
   },
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
-      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "requires": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@actions/http-client": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+          "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+          "requires": {
+            "tunnel": "^0.0.6"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
     },
     "@actions/exec": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "keywords": [],
   "license": "ISC",
   "dependencies": {
-    "@actions/core": "^1.2.6",
+    "@actions/core": "^1.10.0",
     "@actions/exec": "^1.0.1",
     "@actions/io": "^1.1.0",
     "@martijnhols/actions-cache": "^1.1.3"


### PR DESCRIPTION
# Summary of PR changes

- Only include certain files when considering when to increment the tag.
- Remove the restriction on the build workflow, so we always get a status check
- Update actions to their latest tags
- Update action.yml to use Node 16 and increment the minor version for the action
- Update actions/core to v1.10.0 to handle [untrusted logged data](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

## PR Requirements
- [x] For JavaScript actions, the action has been recompiled.  
  - See the *Recompiling* section of the repository's README.md for more details.
  - This does not apply to Composite Run Steps actions unless a package.json is present and contains a build script.
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
